### PR TITLE
Add base group class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,10 @@ jobs:
           name: Code style check
           command: |
             . venv/bin/activate
-            flake8
-            black --check .
+            make lint
       
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
-            pytest --cov pyglyt/
+            make test-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,4 +42,5 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
+            pip install -e .
             make test-coverage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-test:
+lint:
 		flake8
 		cd tests && flake8
 		black --check .
+
+test:
+		pytest --cov pyglyt/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 test:
 		flake8
 		cd tests && flake8
+		black --check .

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,7 @@ lint:
 		black --check .
 
 test:
+		pytest
+
+test-coverage:
 		pytest --cov pyglyt/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+		flake8
+		cd tests && flake8

--- a/pyglyt/group/__init__.py
+++ b/pyglyt/group/__init__.py
@@ -1,0 +1,4 @@
+from .group import Group
+
+
+__all__ = [Group]

--- a/pyglyt/group/group.py
+++ b/pyglyt/group/group.py
@@ -1,3 +1,4 @@
+import itertools
 import operator
 from typing import Any, Callable, Collection
 
@@ -14,9 +15,8 @@ class Group(set):
         self.generators = set(generators)
         self.operation = operation
         self.identity = identity
-        # NOTE: Should `identity` really be `Any` type?
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Repr string for group class"""
         return (
             f"{self.__class__.__name__}<"
@@ -24,3 +24,4 @@ class Group(set):
             f"operation={self.operation!r}, "
             f"identity={self.identity!r}>"
         )
+

--- a/pyglyt/group/group.py
+++ b/pyglyt/group/group.py
@@ -1,0 +1,26 @@
+import operator
+from typing import Any, Callable, Collection
+
+
+class Group(set):
+    """Class implementing an algebraic group"""
+
+    def __init__(
+        self,
+        generators: Collection = (),
+        operation: Callable = operator.add,
+        identity: Any = 0,
+    ) -> None:
+        self.generators = set(generators)
+        self.operation = operation
+        self.identity = identity
+        # NOTE: Should `identity` really be `Any` type?
+
+    def __repr__(self):
+        """Repr string for group class"""
+        return (
+            f"{self.__class__.__name__}<"
+            f"generators={self.generators!r}, "
+            f"operation={self.operation!r}, "
+            f"identity={self.identity!r}>"
+        )

--- a/pyglyt/group/group.py
+++ b/pyglyt/group/group.py
@@ -1,5 +1,4 @@
-import operator
-from typing import Any, Callable, Collection
+from typing import Callable, Collection, Optional
 
 
 class Group(set):
@@ -7,9 +6,9 @@ class Group(set):
 
     def __init__(
         self,
-        generators: Collection = (),
-        operation: Callable = operator.add,
-        identity: Any = 0,
+        generators: Collection,
+        operation: Callable,
+        identity: Optional = None,
     ) -> None:
         self.generators = set(generators)
         self.operation = operation
@@ -18,8 +17,7 @@ class Group(set):
     def __repr__(self) -> str:
         """Repr string for group class"""
         return (
-            f"{self.__class__.__name__}<"
+            f"{self.__class__.__name__}("
             f"generators={self.generators!r}, "
-            f"operation={self.operation!r}, "
-            f"identity={self.identity!r}>"
+            f"operation={self.operation!r})"
         )

--- a/pyglyt/group/group.py
+++ b/pyglyt/group/group.py
@@ -1,4 +1,3 @@
-import itertools
 import operator
 from typing import Any, Callable, Collection
 
@@ -24,4 +23,3 @@ class Group(set):
             f"operation={self.operation!r}, "
             f"identity={self.identity!r}>"
         )
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-exclude = .git,venv
+exclude = .git,venv,tests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+"""Setup script for pyglyt"""
+
+import os.path
+from setuptools import setup
+
+# The directory containing this file
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+# The text of the README file
+with open(os.path.join(HERE, "README.md")) as fid:
+    README = fid.read()
+
+# This call to setup() does all the work
+setup(
+    name="pyglyt",
+    version="0.1.0",
+    description="Computational group, graph and set theory in Python",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    url="https://github.com/somacdivad/pyglyt",
+    author="David Amos",
+    author_email="somacdivad@gmail.com",
+    license="MIT",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ],
+    packages=["pyglyt"],
+    install_requires=[],
+    entry_points={},
+)

--- a/tests/.flake8
+++ b/tests/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=120

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -7,17 +7,17 @@ from pyglyt.group import Group
 
 @pytest.fixture
 def trivial_group():
-    return Group()
+    return Group({0}, operator.add)
 
 
 class TestGroup:
     def test_group_init(self, trivial_group):
         G = trivial_group
         assert set(G.generators) == set()
-        assert G.identity is 0
         assert G.operation == operator.add
+        assert G.identity is None
 
     def test_group_repr(self, trivial_group):
         actual = repr(trivial_group)
-        expected = "Group<generators=set(), operation=<built-in function add>, identity=0>"
+        expected = "Group(generators={0}, operation=<built-in function add>)"
         assert actual == expected

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,0 +1,33 @@
+import operator
+
+import pytest
+
+from pyglyt.group import Group
+
+
+@pytest.fixture
+def trivial_group():
+    return Group()
+
+
+@pytest.fixture(scope="module", params=[0, 0.0])
+def non_iterable(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[0, 0.0, "", [], {}, set()])
+def non_callable(request):
+    return request.param
+
+
+class TestGroup:
+    def test_group_init(self, trivial_group):
+        G = trivial_group
+        assert set(G.generators) == set()
+        assert G.identity is 0
+        assert G.operation == operator.add
+
+    def test_group_repr(self, trivial_group):
+        actual = repr(trivial_group)
+        expected = "Group<generators=set(), operation=<built-in function add>, identity=0>"
+        assert actual == expected

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -21,4 +21,3 @@ class TestGroup:
         actual = repr(trivial_group)
         expected = "Group<generators=set(), operation=<built-in function add>, identity=0>"
         assert actual == expected
-

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -10,16 +10,6 @@ def trivial_group():
     return Group()
 
 
-@pytest.fixture(scope="module", params=[0, 0.0])
-def non_iterable(request):
-    return request.param
-
-
-@pytest.fixture(scope="module", params=[0, 0.0, "", [], {}, set()])
-def non_callable(request):
-    return request.param
-
-
 class TestGroup:
     def test_group_init(self, trivial_group):
         G = trivial_group
@@ -31,3 +21,4 @@ class TestGroup:
         actual = repr(trivial_group)
         expected = "Group<generators=set(), operation=<built-in function add>, identity=0>"
         assert actual == expected
+

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -13,7 +13,7 @@ def trivial_group():
 class TestGroup:
     def test_group_init(self, trivial_group):
         G = trivial_group
-        assert set(G.generators) == set()
+        assert set(G.generators) == {0}
         assert G.operation == operator.add
         assert G.identity is None
 


### PR DESCRIPTION
An extensible `Group` class.

`Group` objects have three instance attributes:

- **generators:** a set of generating elements (defaults to an empty `tuple`)
- **operation:** a group operation (defaults to `operator.add`)
- **identity:** an identity element (defaults to 0)

The reason for setting the default arguments as such is so that instantiating a `Group` object with no parameters creates a trivial group with a single element.

This seems like a good starting point, although a good argument could be made that the `generators` and `operation` arguments should be required, and the `identity` argument should default to `None`.