### PR TITLE
Remove set inheritance from Group class

### DIFF
--- a/pyglyt/group/group.py
+++ b/pyglyt/group/group.py
@@ -1,7 +1,7 @@
 from typing import Callable, Collection, Optional
 
 
-class Group(set):
+class Group:
     """Class implementing an algebraic group"""
 
     def __init__(


### PR DESCRIPTION
The `Group` class does not need to inherit from `set`.